### PR TITLE
Fix Puppet.newtype is deprecated warning.

### DIFF
--- a/lib/puppet/type/constraint.rb
+++ b/lib/puppet/type/constraint.rb
@@ -1,5 +1,5 @@
 module Puppet
-  newtype(:constraint) do
+  Puppet::Type.newtype(:constraint) do
 
     newparam(:resource) do
       desc "A reference to the resource that is being constrained."


### PR DESCRIPTION
Fix the Puppet.newtype is deprecated warning.
